### PR TITLE
Add export-repo-secrets producer workflow

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,20 @@
+permissions: write-all
+name: Export secrets to ESC
+on: [ workflow_dispatch ]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: 1256780
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - uses: pulumi/esc-export-secrets-action@9d6485759b6adff2538ae91f1b77cc96265c9dad # v1
+        with:
+          organization: pulumi
+          org-environment: github-secrets/pulumi-auto-deploy
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Adds a `workflow_dispatch`-triggered workflow that exports this repo's GitHub secrets to the ESC env `github-secrets/pulumi-auto-deploy`. Same producer pattern we are using elsewhere in the org.

This is the producer side of the ESC migration. Once this PR is merged and the workflow is dispatched once to populate the env, #8 can switch its `ESC_ACTION_ENVIRONMENT` from `imports/github-secrets` to `github-secrets/pulumi-auto-deploy` so that repo-scoped keys (e.g. `TRIAGE_WORKFLOW_TOKEN`, used by `new-issues-to-triage.yml`) resolve correctly.