### PR TITLE
Fix export-repo-secrets workflow inputs

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -1,20 +1,25 @@
-permissions: write-all
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Export secrets to ESC
 on: [ workflow_dispatch ]
 jobs:
   export-to-esc:
     runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
         with:
-          app-id: 1256780
+          app-id: 1256780 # Export Secrets GitHub App
           private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
-      - uses: pulumi/esc-export-secrets-action@9d6485759b6adff2538ae91f1b77cc96265c9dad # v1
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@9d6485759b6adff2538ae91f1b77cc96265c9dad # v1
         with:
           organization: pulumi
           org-environment: github-secrets/pulumi-auto-deploy
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
         env:
           GITHUB_SECRETS: ${{ toJSON(secrets) }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The initial dispatch of #13's `export-repo-secrets.yml` failed with `Input required and not supplied: github-token`. The action requires `github-token`, `oidc-auth`, and `oidc-requested-token-type` as `with:` inputs, not as `env`. These changes mirror the working getting-started variant.